### PR TITLE
Standardise API response models across all endpoints

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,79 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+### Development
+```bash
+# Install dependencies
+pip install -r requirements.txt
+
+# Run the FastAPI server locally (with auto-reload)
+uvicorn app.main:app --reload
+
+# Run with Docker Compose (full stack: Asterisk + FastAPI)
+docker-compose up -d --build
+```
+
+### Testing
+```bash
+# Run all tests (must set PYTHONPATH to repo root)
+PYTHONPATH=. pytest
+
+# Run a single test file
+PYTHONPATH=. pytest test/test_main.py
+
+# Run a single test by name
+PYTHONPATH=. pytest test/test_main.py::test_function_name
+```
+
+### Linting
+```bash
+# Check for syntax errors and undefined names (blocking)
+flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+
+# Full lint (non-blocking, max line length 127)
+flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+```
+
+CI runs on push to `dev` and all pull requests via `.github/workflows/python-app.yml`.
+
+## Architecture
+
+**SIPConnectServer** is a FastAPI server that acts as the management and notification layer on top of Asterisk PBX. It enables SIP-based voice communication via USB GSM dongles and pushes call/SMS alerts to Android clients via Firebase.
+
+### Core Data Flow
+
+1. **User Creation**: Admin POSTs to `/sip/users` → JSON database updated → Asterisk config files regenerated → Asterisk restarted
+2. **Device Registration**: Mobile app POSTs FCM token to `/sip/client/register` → stored per user/device in JSON
+3. **Incoming Call/SMS**: Asterisk receives signal from dongle → calls FastAPI `/sip/alert/call` or `/sip/alert/sms` → logged to SQLite → Firebase push notification sent to registered devices
+4. **Outgoing SMS**: Client POSTs to `/gsm/sms` → routed to dongle modem via Asterisk CLI or Firebase
+
+### Key Layers
+
+**API Layer** (`app/main.py`)  
+All HTTP endpoints. Handles user management, device registration, call/SMS alerts, log retrieval, and config upload. Uses Jinja2 templates for the admin dashboard (`/`) and logs page (`/logs`).
+
+**Data Persistence**
+- `app/data.json` — Primary user database (JSON file). Stores SIP users, FCM tokens, OAuth2 tokens, and metadata. Read/written via `app/database.py`.
+- SQLite at `/var/log/asterisk/master.db` — Append-only log of call and SMS events. Accessed via `app/database_sqlite.py`.
+
+**Asterisk Config Generation** (`app/asterisk_config_generator.py` + `app/asterisk_confi_template.py`)  
+Configs for `dongle.conf`, `pjsip.conf`, and `extensions.conf` are generated dynamically from the JSON user database using Jinja2-style templates. The generator writes only the auto-generated section (delimited by a marker), preserving any manually added config above it. Config is regenerated on every user create/update/delete.
+
+**Services** (`app/services/`)
+- `asterisk.py` — Runs Asterisk CLI commands (`asterisk -rx "..."`) for dongle SMS sending and service restart
+- `firebase.py` — Sends push notifications via Firebase Cloud Messaging using OAuth2 service account tokens
+- `gsm.py` — Routes outgoing SMS to either Asterisk dongle or Firebase depending on device type
+
+**Models** (`app/models.py`)  
+Pydantic v2 schemas for all request/response bodies. `Constants.py` defines device type values (Android client, Huawei dongle, dummy).
+
+### Important Constraints
+
+- Asterisk config generation rewrites sections in `dongle.conf`, `pjsip.conf`, and `extensions.conf` — changes to templates in `app/asterisk_confi_template.py` affect all users on next restart.
+- The JSON database (`app/data.json`) is both config and runtime state — it is tracked in git (with real data stripped); keep its schema consistent.
+- Firebase push notifications require a valid service account JSON uploaded via the dashboard (`/upload_sa`). The OAuth2 token is refreshed and cached in the JSON database.
+- The server runs inside Docker alongside Asterisk under `supervisord`. FastAPI runs on port 8000; SIP uses UDP port 5060.
+- Tests in `test/` use mocking extensively to avoid requiring a live Asterisk or Firebase — maintain this pattern when adding tests.

--- a/app/main.py
+++ b/app/main.py
@@ -1,14 +1,17 @@
 import json
 from pathlib import Path
+from typing import List
 
 import aiofiles
 from fastapi import FastAPI, HTTPException, Request, UploadFile, File, Query
-from fastapi.responses import HTMLResponse, RedirectResponse, FileResponse, JSONResponse
+from fastapi.responses import HTMLResponse, RedirectResponse, FileResponse
 from fastapi.templating import Jinja2Templates
 
 import app.database as db
 import app.database_sqlite as sql_db
-from app.models import User, TokenPayload, CallPayload, SmsPayload, RestartPayload, MessageResponse, DeviceResponse
+from app.models import (User, TokenPayload, CallPayload, SmsPayload, RestartPayload,
+                        MessageResponse, DeviceResponse, FirebaseResponse,
+                        SmsLogEntry, CallLogEntry, SmsLogsResponse, CallLogsResponse)
 from app.services.asterisk import restart_asterisk, configure_asterisk
 from app.services.firebase import push_call_alert, push_sms_alert
 from app.tty_devices import read_ttyUSB_devices
@@ -57,21 +60,20 @@ async def get_device_token(username: str = Query(..., description="The username 
     token = db.get_fcm_token(username, device_id) or ""
     return DeviceResponse(fcm_token=token)
 
-@app.post("/sip/alert/call")
+@app.post("/sip/alert/call", response_model=List[FirebaseResponse])
 async def alert_client_on_call(payload: CallPayload):
     if not db.user_exits(payload.username):
         raise HTTPException(status_code=404, detail="User name not present.")
     sql_db.insert_call_log(payload.username, payload.phone_number, payload.model_dump_json())
     return await push_call_alert(payload.username, payload.phone_number, payload.__dict__)
 
-@app.post("/sip/alert/sms", response_model=MessageResponse)
+@app.post("/sip/alert/sms", response_model=List[FirebaseResponse])
 async def alert_client_on_sms(payload: SmsPayload):
     if not db.user_exits(payload.username):
         raise HTTPException(status_code=404, detail="User name not present.")
     sql_db.insert_sms_log(
         payload.username, payload.phone_number, payload.body, "alert sms", payload.model_dump_json())
-    message = await push_sms_alert(payload.username, payload.phone_number, payload.body, payload.device_id)
-    return MessageResponse(message=json.dumps(message))
+    return await push_sms_alert(payload.username, payload.phone_number, payload.body, payload.device_id)
 
 @app.post("/gsm/sms", response_model=MessageResponse)
 async def send_gsm_sms(payload: SmsPayload):
@@ -79,8 +81,10 @@ async def send_gsm_sms(payload: SmsPayload):
         raise HTTPException(status_code=404, detail="User name not present.")
     sql_db.insert_sms_log(
         payload.username, payload.phone_number, payload.body, "gsm sms", payload.model_dump_json())
-    message = await gsm.send_gsm_sms(payload.phone_number, payload.body, payload.username, payload.device_id)
-    return MessageResponse(message=json.dumps(message))
+    result = await gsm.send_gsm_sms(payload.phone_number, payload.body, payload.username, payload.device_id)
+    if isinstance(result, str):
+        return MessageResponse(message=result)
+    return MessageResponse(message=f"SMS forwarded via Firebase to {len(result)} device(s).")
 
 @app.get("/", response_class=HTMLResponse)
 async def dashboard(request: Request):
@@ -106,35 +110,21 @@ async def logs_page(request: Request):
     """Render the logs page (empty table; data loaded via AJAX)."""
     return templates.TemplateResponse("logs.html", {"request": request})
 
-@app.get("/api/logs/sms", response_class=JSONResponse)
+@app.get("/api/logs/sms", response_model=SmsLogsResponse)
 async def get_sms_logs():
-    """Return combined call + SMS logs as JSON."""
     sms_logs = sql_db.get_sms_logs()
-    data = [
-        {
-            "id": log[0],
-            "user": log[1],
-            "number": log[2],
-            "message": log[3],
-            "sms_type": log[4],
-            "timestamp": log[5]
-        } for log in sms_logs
-    ]
-    return JSONResponse(content={"data": data})
+    return SmsLogsResponse(data=[
+        SmsLogEntry(id=log[0], user=log[1], number=log[2], message=log[3], sms_type=log[4], timestamp=log[5])
+        for log in sms_logs
+    ])
 
-@app.get("/api/logs/call", response_class=JSONResponse)
+@app.get("/api/logs/call", response_model=CallLogsResponse)
 async def get_call_logs():
-    """Return combined call + SMS logs as JSON."""
     call_logs = sql_db.get_call_logs()
-    data = [
-        {
-            "id": log[0],
-            "user": log[1],
-            "number": log[2],
-            "timestamp": log[3]
-        } for log in call_logs
-    ]
-    return JSONResponse(content={"data": data})
+    return CallLogsResponse(data=[
+        CallLogEntry(id=log[0], user=log[1], number=log[2], timestamp=log[3])
+        for log in call_logs
+    ])
 
 @app.post("/upload_sa")
 async def upload_service_account_file(config_file: UploadFile = File(...)):
@@ -159,10 +149,9 @@ async def download_db():
     db_file = db.get_db_file_path()
     if Path(db_file).exists():
         return FileResponse(db_file, media_type='application/json', filename="users_db.json")
-    else:
-        return JSONResponse(status_code=404, content={"message": "DB file not found."})
+    raise HTTPException(status_code=404, detail="DB file not found.")
 
-@app.post("/sip/db")
+@app.post("/sip/db", response_model=MessageResponse)
 async def upload_db(db_file: UploadFile = File(...)):
     try:
         db_file_path = db.get_db_file_path()
@@ -171,9 +160,9 @@ async def upload_db(db_file: UploadFile = File(...)):
             await f.write(contents)
         db.load_data(True)
         message = await configure_asterisk()
-        return {"message": "Database restored successfully. " + message}
+        return MessageResponse(message="Database restored successfully. " + message)
     except Exception as e:
-        return JSONResponse(status_code=500, content={"message": f"Error: {str(e)}"})
+        raise HTTPException(status_code=500, detail=f"Error: {str(e)}")
 
 @app.post("/sip/restart", response_model=MessageResponse)
 async def restart_sip_server(payload: RestartPayload):

--- a/app/main.py
+++ b/app/main.py
@@ -84,7 +84,7 @@ async def send_gsm_sms(payload: SmsPayload):
     result = await gsm.send_gsm_sms(payload.phone_number, payload.body, payload.username, payload.device_id)
     if isinstance(result, str):
         return MessageResponse(message=result)
-    return MessageResponse(message=f"SMS forwarded via Firebase to {len(result)} device(s).")
+    return MessageResponse(message=f"SMS forwarded via GSM/Firebase to {len(result)} device(s).")
 
 @app.get("/", response_class=HTMLResponse)
 async def dashboard(request: Request):

--- a/app/models.py
+++ b/app/models.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import List, Optional
 
 from pydantic import BaseModel, Field
 
@@ -60,3 +60,27 @@ class RestartPayload(BaseModel):
     username: str
     device_id: str = Field(
         None, description="Device id from which this restart request was sent.")
+
+class FirebaseResponse(BaseModel):
+    status: int
+    data: dict
+
+class SmsLogEntry(BaseModel):
+    id: int
+    user: str
+    number: str
+    message: str
+    sms_type: str
+    timestamp: str
+
+class CallLogEntry(BaseModel):
+    id: int
+    user: str
+    number: str
+    timestamp: str
+
+class SmsLogsResponse(BaseModel):
+    data: List[SmsLogEntry]
+
+class CallLogsResponse(BaseModel):
+    data: List[CallLogEntry]

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -46,7 +46,7 @@ class TestMain(unittest.IsolatedAsyncioTestCase):
     def test_alert_client_on_call_success(self, mock_push_call_alert, mock_db, mock_sql_db):
         mock_db.user_exits.return_value = True
         mock_sql_db.insert_call_log.return_value = None
-        mock_push_call_alert.return_value = {"status": "sent"}
+        mock_push_call_alert.return_value = [{"status": 200, "data": {"name": "projects/test/messages/123"}}]
         payload = {
             "username": "sip_user",
             "phone_number": "+1234567890",
@@ -59,7 +59,7 @@ class TestMain(unittest.IsolatedAsyncioTestCase):
         mock_db.user_exits.assert_called_once_with("sip_user")
         mock_push_call_alert.assert_awaited_once_with("sip_user", "+1234567890", payload)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), {"status": "sent"})
+        self.assertEqual(response.json(), [{"status": 200, "data": {"name": "projects/test/messages/123"}}])
 
     @patch("app.main.db")
     def test_alert_client_on_call_user_not_found(self, mock_db):
@@ -81,7 +81,7 @@ class TestMain(unittest.IsolatedAsyncioTestCase):
     def test_alert_client_on_sms_success(self, mock_push_sms_alert, mock_db, mock_sql_db):
         mock_db.user_exits.return_value = True
         mock_sql_db.insert_sms_log.return_value = None
-        mock_push_sms_alert.return_value = {"status": "sent"}
+        mock_push_sms_alert.return_value = [{"status": 200, "data": {"name": "projects/test/messages/456"}}]
         payload = {
             "username": "sip_user",
             "phone_number": "+1234567890",
@@ -96,7 +96,7 @@ class TestMain(unittest.IsolatedAsyncioTestCase):
         mock_db.user_exits.assert_called_once_with("sip_user")
         mock_push_sms_alert.assert_awaited_once_with("sip_user", "+1234567890", "Hello!", None)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), {"message": '{"status": "sent"}'})
+        self.assertEqual(response.json(), [{"status": 200, "data": {"name": "projects/test/messages/456"}}])
 
     @patch("app.main.db")
     def test_alert_client_on_sms_user_not_found(self, mock_db):


### PR DESCRIPTION
- Add FirebaseResponse, SmsLogEntry, CallLogEntry, SmsLogsResponse, CallLogsResponse Pydantic models
- Fix /sip/alert/call and /sip/alert/sms to return List[FirebaseResponse] instead of untyped / double-serialised json.dumps() values
- Fix /gsm/sms to normalise str|list return into MessageResponse
- Replace inline dicts in log endpoints with typed Pydantic wrapper models
- Replace JSONResponse error returns in /sip/db with raise HTTPException to unify all error shapes under {"detail": "..."}
- Remove unused JSONResponse import
- Update tests to assert corrected response shapes