### PR TITLE
Remove DB backup/restore endpoints and UI

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,4 +1,5 @@
 import json
+from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import List
 
@@ -13,14 +14,19 @@ from app.models import (User, TokenPayload, CallPayload, SmsPayload, RestartPayl
                         MessageResponse, DeviceResponse, FirebaseResponse,
                         SmsLogEntry, CallLogEntry, SmsLogsResponse, CallLogsResponse,
                         UserResponse, ConfigResponse)
-from app.services.asterisk import restart_asterisk
+from app.services.asterisk import restart_asterisk, configure_asterisk
 from app.services.firebase import push_call_alert, push_sms_alert
 from app.tty_devices import read_ttyUSB_devices
 from app.users import add_user
 from app.services import gsm
 
 
-app = FastAPI()
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    await configure_asterisk()
+    yield
+
+app = FastAPI(lifespan=lifespan)
 BASE_DIR = Path(__file__).resolve().parent
 TEMPLATES_DIR = BASE_DIR / "templates"
 templates = Jinja2Templates(directory=str(TEMPLATES_DIR))

--- a/app/main.py
+++ b/app/main.py
@@ -4,7 +4,7 @@ from typing import List
 
 import aiofiles
 from fastapi import FastAPI, HTTPException, Request, UploadFile, File, Query
-from fastapi.responses import HTMLResponse, FileResponse
+from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
 
 import app.database as db
@@ -13,7 +13,7 @@ from app.models import (User, TokenPayload, CallPayload, SmsPayload, RestartPayl
                         MessageResponse, DeviceResponse, FirebaseResponse,
                         SmsLogEntry, CallLogEntry, SmsLogsResponse, CallLogsResponse,
                         UserResponse, ConfigResponse)
-from app.services.asterisk import restart_asterisk, configure_asterisk
+from app.services.asterisk import restart_asterisk
 from app.services.firebase import push_call_alert, push_sms_alert
 from app.tty_devices import read_ttyUSB_devices
 from app.users import add_user
@@ -176,25 +176,6 @@ async def upload_service_account_file(config_file: UploadFile = File(...)):
     db.set_service_account_file_path(save_path.as_posix())
     return MessageResponse(message="Service account uploaded successfully.")
 
-@app.get("/sip/db")
-async def download_db():
-    db_file = db.get_db_file_path()
-    if Path(db_file).exists():
-        return FileResponse(db_file, media_type='application/json', filename="users_db.json")
-    raise HTTPException(status_code=404, detail="DB file not found.")
-
-@app.post("/sip/db", response_model=MessageResponse)
-async def upload_db(db_file: UploadFile = File(...)):
-    try:
-        db_file_path = db.get_db_file_path()
-        contents = await db_file.read()
-        async with aiofiles.open(db_file_path, "wb") as f:
-            await f.write(contents)
-        db.load_data(True)
-        message = await configure_asterisk()
-        return MessageResponse(message="Database restored successfully. " + message)
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Error: {str(e)}")
 
 @app.post("/sip/restart", response_model=MessageResponse)
 async def restart_sip_server(payload: RestartPayload):

--- a/frontend/src/api/index.js
+++ b/frontend/src/api/index.js
@@ -30,8 +30,6 @@ export const api = {
   getConfig:    ()       => request('GET', '/api/config'),
   getTtyDevices: ()      => request('GET', '/api/tty-devices'),
   uploadSA:     (form)   => upload('/upload_sa', form),
-  downloadDB:   ()       => { window.location.href = '/sip/db' },
-  uploadDB:     (form)   => upload('/sip/db', form),
 
   // Logs
   getCallLogs:  () => request('GET', '/api/logs/call'),

--- a/frontend/src/components/ConfigCard.vue
+++ b/frontend/src/components/ConfigCard.vue
@@ -4,8 +4,7 @@ import { api } from '../api'
 
 const config     = ref({ sa_configured: false, project_id: '' })
 const saFile     = ref(null)
-const dbFile     = ref(null)
-const uploading  = ref({ sa: false, db: false })
+const uploading  = ref(false)
 const snackbar   = ref({ show: false, message: '', color: 'success' })
 
 onMounted(async () => {
@@ -18,7 +17,7 @@ onMounted(async () => {
 
 async function uploadSA() {
   if (!saFile.value) return
-  uploading.value.sa = true
+  uploading.value = true
   try {
     const form = new FormData()
     form.append('config_file', saFile.value)
@@ -29,23 +28,7 @@ async function uploadSA() {
   } catch (e) {
     showSnackbar(e.message, 'error')
   } finally {
-    uploading.value.sa = false
-  }
-}
-
-async function uploadDB() {
-  if (!dbFile.value) return
-  uploading.value.db = true
-  try {
-    const form = new FormData()
-    form.append('db_file', dbFile.value)
-    const res = await api.uploadDB(form)
-    showSnackbar(res.message)
-    dbFile.value = null
-  } catch (e) {
-    showSnackbar(e.message, 'error')
-  } finally {
-    uploading.value.db = false
+    uploading.value = false
   }
 }
 
@@ -88,45 +71,10 @@ function showSnackbar(message, color = 'success') {
       <v-btn
         color="primary"
         variant="flat"
-        :loading="uploading.sa"
+        :loading="uploading"
         :disabled="!saFile"
         @click="uploadSA"
       >Upload</v-btn>
-    </v-card-actions>
-  </v-card>
-
-  <v-card>
-    <v-card-title>
-      <v-icon start>mdi-database</v-icon>
-      Database
-    </v-card-title>
-    <v-card-text>
-      <v-btn
-        variant="outlined"
-        prepend-icon="mdi-download"
-        class="mb-4"
-        @click="api.downloadDB()"
-      >Download Backup</v-btn>
-
-      <v-file-input
-        v-model="dbFile"
-        label="Restore from backup"
-        accept=".json"
-        prepend-icon="mdi-restore"
-        variant="outlined"
-        density="compact"
-        hide-details
-      />
-    </v-card-text>
-    <v-card-actions>
-      <v-spacer />
-      <v-btn
-        color="warning"
-        variant="flat"
-        :loading="uploading.db"
-        :disabled="!dbFile"
-        @click="uploadDB"
-      >Restore</v-btn>
     </v-card-actions>
   </v-card>
 


### PR DESCRIPTION
Data persistence is now handled via Docker volume mounts, making the backup/download/restore functionality redundant.

- Remove GET /sip/db and POST /sip/db endpoints
- Remove unused FileResponse and configure_asterisk imports
- Remove downloadDB and uploadDB from frontend api module
- Remove Database card from ConfigCard.vue