### PR TITLE
Add web push notifications for Chrome/Firefox

### DIFF
--- a/app/Constants.py
+++ b/app/Constants.py
@@ -6,3 +6,4 @@ class Const:
     DEV_DUMMY = "dummy"
     DEV_ANDROID = "android"
     DEV_DONGLE_HUAWEI = "huawei dongle"
+    DEV_WEB_PUSH = "web browser"

--- a/app/database.py
+++ b/app/database.py
@@ -4,6 +4,10 @@ import os
 from pathlib import Path
 from typing import List, Optional
 
+from cryptography.hazmat.primitives import serialization
+from py_vapid import Vapid
+from py_vapid.utils import b64urlencode
+
 # For this simple application, lets use file as database
 BASE_DIR = Path(__file__).resolve().parent
 # DB_FILE = os.path.join('app', 'data.json')
@@ -89,7 +93,7 @@ def get_fcm_tokens(username: str) -> List[str]:
     user_data = get_user_data(username)
     if not user_data.get('devices'):
         return []
-    tokens = [x['fcm_token'] for x in user_data['devices'].values()]
+    tokens = [x['fcm_token'] for x in user_data['devices'].values() if x.get('fcm_token')]
     return tokens
 
 def get_fcm_token(username: str, device_id: str) -> Optional[str]:
@@ -103,8 +107,43 @@ def get_fcm_tokens_with_device_id(username: str) -> dict:
     user_data = get_user_data(username)
     if not user_data.get('devices'):
         return {}
-    tokens = {x['device_id']: x['fcm_token'] for x in user_data['devices'].values()}
+    tokens = {x['device_id']: x['fcm_token'] for x in user_data['devices'].values() if x.get('fcm_token')}
     return tokens
+
+def update_web_subscription(username: str, device_id: str, subscription: dict) -> str:
+    user_data = get_user_data(username)
+    if not user_data:
+        return f"No device found with username '{username}'."
+
+    if not user_data.get('devices'):
+        user_data['devices'] = {}
+    user_data['devices'].setdefault(device_id, {'device_id': device_id})
+    user_data['devices'][device_id]['web_subscription'] = subscription
+    save_data()
+    return f"Web push subscription updated for user '{username}'."
+
+def get_web_subscriptions(username: str) -> List[dict]:
+    user_data = get_user_data(username)
+    if not user_data or not user_data.get('devices'):
+        return []
+    return [x['web_subscription'] for x in user_data['devices'].values() if x.get('web_subscription')]
+
+def get_web_subscriptions_with_device_id(username: str) -> dict:
+    user_data = get_user_data(username)
+    if not user_data or not user_data.get('devices'):
+        return {}
+    return {
+        x['device_id']: x['web_subscription']
+        for x in user_data['devices'].values() if x.get('web_subscription')
+    }
+
+def remove_device(username: str, device_id: str) -> str:
+    user_data = get_user_data(username)
+    if not user_data or not user_data.get('devices') or device_id not in user_data['devices']:
+        return f"No device '{device_id}' found for user '{username}'."
+    del user_data['devices'][device_id]
+    save_data()
+    return f"Device '{device_id}' removed for user '{username}'."
 
 def update_oauth2_token(username: str, new_oauth2_token: str, expiry: int):
     user_data = get_user_data(username)
@@ -143,6 +182,25 @@ def get_service_account_file_path() -> str:
 def set_service_account_file_path(sa_path: str):
     _DB_FULL['app-config']['service_account_file'] = sa_path
     save_data()
+
+def get_vapid_keys() -> dict:
+    load_data()
+    config = _DB_FULL.setdefault('app-config', {})
+    if not config.get('vapid_private_key') or not config.get('vapid_public_key'):
+        vapid = Vapid()
+        vapid.generate_keys()
+        private_raw = vapid.private_key.private_numbers().private_value.to_bytes(32, 'big')
+        public_raw = vapid.public_key.public_bytes(
+            serialization.Encoding.X962, serialization.PublicFormat.UncompressedPoint)
+        config['vapid_private_key'] = b64urlencode(private_raw)
+        config['vapid_public_key'] = b64urlencode(public_raw)
+        config.setdefault('vapid_subject', 'mailto:admin@example.com')
+        save_data()
+    return {
+        'private_key': config['vapid_private_key'],
+        'public_key': config['vapid_public_key'],
+        'subject': config.get('vapid_subject', 'mailto:admin@example.com'),
+    }
 
 def add_dummy_user():
     data = get_all_users()

--- a/app/main.py
+++ b/app/main.py
@@ -13,9 +13,10 @@ import app.database_sqlite as sql_db
 from app.models import (User, TokenPayload, CallPayload, SmsPayload, RestartPayload,
                         MessageResponse, DeviceResponse, FirebaseResponse,
                         SmsLogEntry, CallLogEntry, SmsLogsResponse, CallLogsResponse,
-                        UserResponse, ConfigResponse)
+                        UserResponse, ConfigResponse, WebPushTokenPayload, VapidKeyResponse)
 from app.services.asterisk import restart_asterisk, configure_asterisk
 from app.services.firebase import push_call_alert, push_sms_alert
+from app.services.webpush import push_web_call_alert, push_web_sms_alert
 from app.tty_devices import read_ttyUSB_devices
 from app.users import add_user
 from app.services import gsm
@@ -102,12 +103,25 @@ async def get_device_token(username: str = Query(..., description="The username 
     token = db.get_fcm_token(username, device_id) or ""
     return DeviceResponse(fcm_token=token)
 
+@app.get("/api/vapid-public-key", response_model=VapidKeyResponse)
+async def get_vapid_public_key():
+    return VapidKeyResponse(public_key=db.get_vapid_keys()["public_key"])
+
+@app.post("/sip/client/register/web-push", response_model=MessageResponse)
+async def register_web_push(payload: WebPushTokenPayload):
+    if not db.user_exits(payload.username):
+        raise HTTPException(status_code=404, detail="User name not present.")
+    message = db.update_web_subscription(payload.username, payload.device_id, payload.subscription.model_dump())
+    return MessageResponse(message=message)
+
 @app.post("/sip/alert/call", response_model=List[FirebaseResponse])
 async def alert_client_on_call(payload: CallPayload):
     if not db.user_exits(payload.username):
         raise HTTPException(status_code=404, detail="User name not present.")
     sql_db.insert_call_log(payload.username, payload.phone_number, payload.model_dump_json())
-    return await push_call_alert(payload.username, payload.phone_number, payload.__dict__)
+    fcm_results = await push_call_alert(payload.username, payload.phone_number, payload.__dict__)
+    web_results = await push_web_call_alert(payload.username, payload.phone_number, payload.__dict__)
+    return fcm_results + web_results
 
 @app.post("/sip/alert/sms", response_model=List[FirebaseResponse])
 async def alert_client_on_sms(payload: SmsPayload):
@@ -115,7 +129,9 @@ async def alert_client_on_sms(payload: SmsPayload):
         raise HTTPException(status_code=404, detail="User name not present.")
     sql_db.insert_sms_log(
         payload.username, payload.phone_number, payload.body, "alert sms", payload.model_dump_json())
-    return await push_sms_alert(payload.username, payload.phone_number, payload.body, payload.device_id)
+    fcm_results = await push_sms_alert(payload.username, payload.phone_number, payload.body, payload.device_id)
+    web_results = await push_web_sms_alert(payload.username, payload.phone_number, payload.body, payload.device_id)
+    return fcm_results + web_results
 
 @app.post("/gsm/sms", response_model=MessageResponse)
 async def send_gsm_sms(payload: SmsPayload):

--- a/app/models.py
+++ b/app/models.py
@@ -41,6 +41,22 @@ class TokenPayload(BaseModel):
 class DeviceResponse(BaseModel):
     fcm_token: str
 
+class PushSubscriptionKeys(BaseModel):
+    p256dh: str
+    auth: str
+
+class WebPushSubscription(BaseModel):
+    endpoint: str
+    keys: PushSubscriptionKeys
+
+class WebPushTokenPayload(BaseModel):
+    device_id: str
+    subscription: WebPushSubscription
+    username: str
+
+class VapidKeyResponse(BaseModel):
+    public_key: str
+
 class CallPayload(BaseModel):
     username: str
     phone_number: str

--- a/app/services/webpush.py
+++ b/app/services/webpush.py
@@ -1,0 +1,51 @@
+import asyncio
+import json
+from datetime import datetime, timezone
+
+from pywebpush import webpush, WebPushException
+
+from app.database import (get_vapid_keys, get_web_subscriptions_with_device_id, remove_device)
+
+
+async def push_web_call_alert(username: str, phone_number: str, payload: dict = None):
+    subscriptions = get_web_subscriptions_with_device_id(username)
+    data = {"type": "call", "phone_number": phone_number}
+    if payload and payload.get("type") == "missed":
+        data["type"] = "missed-call"
+    title = "Missed Call" if data["type"] == "missed-call" else "Incoming Call"
+    return await asyncio.gather(*[
+        send_web_push(username, device_id, subscription, title, phone_number, data)
+        for device_id, subscription in subscriptions.items()
+    ])
+
+async def push_web_sms_alert(
+        username: str, phone_number: str, message_body: str, from_device: str = None, forward_to_gsm: bool = False):
+    subscriptions = get_web_subscriptions_with_device_id(username)
+    if from_device:
+        subscriptions = {k: v for k, v in subscriptions.items() if k != from_device}
+    data = {"type": "sms", "phone_number": phone_number, "body": message_body, "forward_to_gsm": str(forward_to_gsm)}
+    title = f"New SMS from {phone_number}"
+    return await asyncio.gather(*[
+        send_web_push(username, device_id, subscription, title, message_body, data)
+        for device_id, subscription in subscriptions.items()
+    ])
+
+async def send_web_push(username: str, device_id: str, subscription: dict, title: str, body: str, data: dict) -> dict:
+    data = {**data, "timestamp": datetime.now(timezone.utc).isoformat(timespec='seconds')}
+    notification = {"title": title, "body": body, "data": data}
+    vapid_keys = get_vapid_keys()
+
+    try:
+        response = await asyncio.to_thread(
+            webpush,
+            subscription_info=subscription,
+            data=json.dumps(notification),
+            vapid_private_key=vapid_keys["private_key"],
+            vapid_claims={"sub": vapid_keys["subject"]},
+        )
+        return {"status": response.status_code, "data": {"message": "Push sent"}}
+    except WebPushException as exc:
+        status = exc.response.status_code if exc.response is not None else 500
+        if status in (404, 410):
+            remove_device(username, device_id)
+        return {"status": status, "data": {"error": str(exc)}}

--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -1,0 +1,21 @@
+self.addEventListener('push', (event) => {
+  const payload = event.data ? event.data.json() : {}
+  const title = payload.title || 'SIPConnect'
+  const options = {
+    body: payload.body || '',
+    icon: '/favicon.ico',
+    data: payload.data || {},
+  }
+  event.waitUntil(self.registration.showNotification(title, options))
+})
+
+self.addEventListener('notificationclick', (event) => {
+  event.notification.close()
+  event.waitUntil(
+    self.clients.matchAll({ type: 'window' }).then((clientsArr) => {
+      const existing = clientsArr.find((c) => c.url.includes(self.location.origin))
+      if (existing) return existing.focus()
+      return self.clients.openWindow('/')
+    })
+  )
+})

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -12,6 +12,7 @@ const route = useRoute()
       </v-app-bar-title>
       <v-btn variant="text" to="/" :active="route.path === '/'">Dashboard</v-btn>
       <v-btn variant="text" to="/logs" :active="route.path === '/logs'">Logs</v-btn>
+      <v-btn variant="text" to="/notifications" :active="route.path === '/notifications'">Notifications</v-btn>
     </v-app-bar>
 
     <v-main class="bg-grey-lighten-4">

--- a/frontend/src/api/index.js
+++ b/frontend/src/api/index.js
@@ -34,4 +34,8 @@ export const api = {
   // Logs
   getCallLogs:  () => request('GET', '/api/logs/call'),
   getSmsLogs:   () => request('GET', '/api/logs/sms'),
+
+  // Web Push
+  getVapidPublicKey: ()   => request('GET',  '/api/vapid-public-key'),
+  registerWebPush:   (data) => request('POST', '/sip/client/register/web-push', data),
 }

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -1,10 +1,12 @@
 import { createRouter, createWebHistory } from 'vue-router'
 import Dashboard from '../views/Dashboard.vue'
 import Logs from '../views/Logs.vue'
+import Notifications from '../views/Notifications.vue'
 
 const routes = [
   { path: '/', component: Dashboard },
   { path: '/logs', component: Logs },
+  { path: '/notifications', component: Notifications },
 ]
 
 export default createRouter({

--- a/frontend/src/views/Notifications.vue
+++ b/frontend/src/views/Notifications.vue
@@ -1,0 +1,125 @@
+<script setup>
+import { ref, onMounted } from 'vue'
+import { api } from '../api'
+
+const username    = ref(localStorage.getItem('notif_username') || '')
+const supported   = ref('serviceWorker' in navigator && 'PushManager' in window)
+const subscribed  = ref(false)
+const loading     = ref(false)
+const snackbar    = ref({ show: false, message: '', color: 'success' })
+
+function showSnackbar(message, color = 'success') {
+  snackbar.value = { show: true, message, color }
+}
+
+function urlBase64ToUint8Array(base64String) {
+  const padding = '='.repeat((4 - (base64String.length % 4)) % 4)
+  const base64 = (base64String + padding).replace(/-/g, '+').replace(/_/g, '/')
+  const rawData = atob(base64)
+  return Uint8Array.from([...rawData].map((c) => c.charCodeAt(0)))
+}
+
+function getDeviceId() {
+  let deviceId = localStorage.getItem('notif_device_id')
+  if (!deviceId) {
+    deviceId = crypto.randomUUID()
+    localStorage.setItem('notif_device_id', deviceId)
+  }
+  return deviceId
+}
+
+onMounted(async () => {
+  if (!supported.value) return
+  const registration = await navigator.serviceWorker.register('/sw.js')
+  const subscription = await registration.pushManager.getSubscription()
+  subscribed.value = !!subscription
+})
+
+async function enableNotifications() {
+  if (!username.value) {
+    showSnackbar('Please enter a username.', 'error')
+    return
+  }
+  localStorage.setItem('notif_username', username.value)
+  loading.value = true
+  try {
+    const permission = await Notification.requestPermission()
+    if (permission !== 'granted') {
+      showSnackbar('Notification permission denied.', 'error')
+      return
+    }
+
+    const registration = await navigator.serviceWorker.register('/sw.js')
+    let subscription = await registration.pushManager.getSubscription()
+    if (!subscription) {
+      const { public_key } = await api.getVapidPublicKey()
+      subscription = await registration.pushManager.subscribe({
+        userVisibleOnly: true,
+        applicationServerKey: urlBase64ToUint8Array(public_key),
+      })
+    }
+
+    await api.registerWebPush({
+      username: username.value,
+      device_id: getDeviceId(),
+      subscription: subscription.toJSON(),
+    })
+
+    subscribed.value = true
+    showSnackbar('Browser notifications enabled.')
+  } catch (e) {
+    showSnackbar(e.message, 'error')
+  } finally {
+    loading.value = false
+  }
+}
+</script>
+
+<template>
+  <v-container fluid class="pa-2 pa-sm-6">
+    <v-card class="mb-4">
+      <v-card-title>
+        <v-icon start>mdi-bell-ring</v-icon>
+        Browser Notifications
+      </v-card-title>
+      <v-card-text>
+        <v-alert v-if="!supported" type="warning" class="mb-4">
+          This browser does not support push notifications.
+        </v-alert>
+
+        <v-chip v-if="supported" :color="subscribed ? 'success' : 'warning'" class="mb-3">
+          {{ subscribed ? 'Notifications Enabled' : 'Notifications Not Enabled' }}
+        </v-chip>
+
+        <p class="text-body-2 text-medium-emphasis mb-4">
+          Enter your SIP username to receive call and SMS alerts as browser notifications
+          on this device.
+        </p>
+
+        <v-text-field
+          v-model="username"
+          label="SIP Username"
+          variant="outlined"
+          density="compact"
+          :disabled="!supported"
+          hide-details
+          class="mb-4"
+        />
+      </v-card-text>
+      <v-card-actions>
+        <v-spacer />
+        <v-btn
+          color="primary"
+          variant="flat"
+          :loading="loading"
+          :disabled="!supported"
+          @click="enableNotifications"
+        >Enable Browser Notifications</v-btn>
+      </v-card-actions>
+    </v-card>
+
+    <v-snackbar v-model="snackbar.show" :color="snackbar.color" :timeout="3000">
+      {{ snackbar.message }}
+    </v-snackbar>
+  </v-container>
+</template>

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ pydantic~=2.11.7
 aiofiles~=24.1.0
 jinja2
 python-multipart
+pywebpush~=2.0.0

--- a/test/services/test_webpush.py
+++ b/test/services/test_webpush.py
@@ -1,0 +1,110 @@
+
+import unittest
+from unittest.mock import patch, AsyncMock, MagicMock
+
+from pywebpush import WebPushException
+from app.services.webpush import push_web_call_alert, push_web_sms_alert, send_web_push
+
+VAPID_KEYS = {"private_key": "mock_private_key", "public_key": "mock_public_key", "subject": "mailto:admin@example.com"}
+
+class TestPushWebAlerts(unittest.IsolatedAsyncioTestCase):
+
+    @patch("app.services.webpush.get_web_subscriptions_with_device_id")
+    @patch("app.services.webpush.send_web_push", new_callable=AsyncMock)
+    async def test_push_web_call_alert_normal_call(self, mock_send_web_push, mock_get_subscriptions):
+        mock_get_subscriptions.return_value = {"dev1": {"endpoint": "https://push.example.com/1"}}
+        mock_send_web_push.return_value = {"status": 201, "data": {"message": "Push sent"}}
+
+        result = await push_web_call_alert("sip_user1", "+1234567890")
+
+        mock_get_subscriptions.assert_called_once_with("sip_user1")
+        mock_send_web_push.assert_awaited_once_with(
+            "sip_user1", "dev1", {"endpoint": "https://push.example.com/1"},
+            "Incoming Call", "+1234567890", {"type": "call", "phone_number": "+1234567890"}
+        )
+        self.assertEqual(result, [{"status": 201, "data": {"message": "Push sent"}}])
+
+    @patch("app.services.webpush.get_web_subscriptions_with_device_id")
+    @patch("app.services.webpush.send_web_push", new_callable=AsyncMock)
+    async def test_push_web_call_alert_missed_call(self, mock_send_web_push, mock_get_subscriptions):
+        mock_get_subscriptions.return_value = {"dev1": {"endpoint": "https://push.example.com/1"}}
+        mock_send_web_push.return_value = {"status": 201, "data": {"message": "Push sent"}}
+
+        result = await push_web_call_alert("sip_user1", "+1234567890", {"type": "missed"})
+
+        mock_send_web_push.assert_awaited_once_with(
+            "sip_user1", "dev1", {"endpoint": "https://push.example.com/1"},
+            "Missed Call", "+1234567890", {"type": "missed-call", "phone_number": "+1234567890"}
+        )
+        self.assertEqual(result, [{"status": 201, "data": {"message": "Push sent"}}])
+
+    @patch("app.services.webpush.get_web_subscriptions_with_device_id")
+    @patch("app.services.webpush.send_web_push", new_callable=AsyncMock)
+    async def test_push_web_sms_alert(self, mock_send_web_push, mock_get_subscriptions):
+        mock_get_subscriptions.return_value = {"dev1": {"endpoint": "https://push.example.com/1"}}
+        mock_send_web_push.return_value = {"status": 201, "data": {"message": "Push sent"}}
+
+        result = await push_web_sms_alert("sip_user1", "+1234567890", "Hello, this is a test SMS.")
+
+        mock_send_web_push.assert_awaited_once_with(
+            "sip_user1", "dev1", {"endpoint": "https://push.example.com/1"},
+            "New SMS from +1234567890", "Hello, this is a test SMS.",
+            {"type": "sms", "phone_number": "+1234567890", "body": "Hello, this is a test SMS.", "forward_to_gsm": "False"}
+        )
+        self.assertEqual(result, [{"status": 201, "data": {"message": "Push sent"}}])
+
+    @patch("app.services.webpush.get_web_subscriptions_with_device_id")
+    @patch("app.services.webpush.send_web_push", new_callable=AsyncMock)
+    async def test_push_web_sms_alert_filter_device(self, mock_send_web_push, mock_get_subscriptions):
+        mock_get_subscriptions.return_value = {
+            "dev1": {"endpoint": "https://push.example.com/1"},
+            "dev2": {"endpoint": "https://push.example.com/2"},
+        }
+        mock_send_web_push.return_value = {"status": 201, "data": {"message": "Push sent"}}
+
+        result = await push_web_sms_alert("sip_user1", "+1234567890", "Hello", "dev2")
+
+        mock_send_web_push.assert_awaited_once_with(
+            "sip_user1", "dev1", {"endpoint": "https://push.example.com/1"},
+            "New SMS from +1234567890", "Hello",
+            {"type": "sms", "phone_number": "+1234567890", "body": "Hello", "forward_to_gsm": "False"}
+        )
+        self.assertEqual(result, [{"status": 201, "data": {"message": "Push sent"}}])
+
+    @patch("app.services.webpush.get_vapid_keys")
+    @patch("app.services.webpush.webpush")
+    async def test_send_web_push_success(self, mock_webpush, mock_get_vapid_keys):
+        mock_get_vapid_keys.return_value = VAPID_KEYS
+        mock_response = MagicMock()
+        mock_response.status_code = 201
+        mock_webpush.return_value = mock_response
+
+        subscription = {"endpoint": "https://push.example.com/1", "keys": {"p256dh": "p256", "auth": "auth"}}
+        data = {"type": "call", "phone_number": "+1234567890"}
+        result = await send_web_push("sip_user1", "dev1", subscription, "Incoming Call", "+1234567890", data)
+
+        self.assertEqual(result, {"status": 201, "data": {"message": "Push sent"}})
+        kwargs = mock_webpush.call_args.kwargs
+        self.assertEqual(kwargs["subscription_info"], subscription)
+        self.assertEqual(kwargs["vapid_private_key"], "mock_private_key")
+        self.assertEqual(kwargs["vapid_claims"], {"sub": "mailto:admin@example.com"})
+
+    @patch("app.services.webpush.remove_device")
+    @patch("app.services.webpush.get_vapid_keys")
+    @patch("app.services.webpush.webpush")
+    async def test_send_web_push_expired_subscription_removed(self, mock_webpush, mock_get_vapid_keys, mock_remove_device):
+        mock_get_vapid_keys.return_value = VAPID_KEYS
+        mock_response = MagicMock()
+        mock_response.status_code = 410
+        mock_webpush.side_effect = WebPushException("Push failed: 410 Gone", response=mock_response)
+
+        subscription = {"endpoint": "https://push.example.com/1", "keys": {"p256dh": "p256", "auth": "auth"}}
+        data = {"type": "call", "phone_number": "+1234567890"}
+        result = await send_web_push("sip_user1", "dev1", subscription, "Incoming Call", "+1234567890", data)
+
+        self.assertEqual(result["status"], 410)
+        mock_remove_device.assert_called_once_with("sip_user1", "dev1")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_database.py
+++ b/test/test_database.py
@@ -60,6 +60,12 @@ class TestDatabase(unittest.TestCase):
         tokens = db.get_fcm_tokens('user1')
         self.assertEqual(tokens, [])
 
+    def test_get_fcm_tokens_ignores_web_push_only_devices(self):
+        subscription = {"endpoint": "https://push.example.com/1", "keys": {"p256dh": "p256", "auth": "auth"}}
+        db.update_web_subscription("user1", "web-dev1", subscription)
+        self.assertEqual(db.get_fcm_tokens("user1"), ["test_fcm_token"])
+        self.assertEqual(db.get_fcm_tokens_with_device_id("user1"), {"dev1": "test_fcm_token"})
+
     def test_get_fcm_token(self):
         # device exists
         token = db.get_fcm_token('user1', 'dev1')
@@ -132,6 +138,47 @@ class TestDatabase(unittest.TestCase):
         db.set_service_account_file_path('new_file_path.json')
         file_path = db.get_service_account_file_path()
         self.assertEqual(file_path, 'new_file_path.json')
+
+    def test_update_web_subscription(self):
+        subscription = {"endpoint": "https://push.example.com/1", "keys": {"p256dh": "p256", "auth": "auth"}}
+        resp = db.update_web_subscription("user1", "web-dev1", subscription)
+        self.assertTrue(resp.startswith("Web push subscription updated"))
+        self.assertEqual(db.get_web_subscriptions("user1"), [subscription])
+
+    def test_update_web_subscription_user_not_found(self):
+        resp = db.update_web_subscription("unknown", "web-dev1", {})
+        self.assertEqual(resp, "No device found with username 'unknown'.")
+
+    def test_get_web_subscriptions_none(self):
+        self.assertEqual(db.get_web_subscriptions("user1"), [])
+
+    def test_get_web_subscriptions_with_device_id(self):
+        subscription = {"endpoint": "https://push.example.com/1", "keys": {"p256dh": "p256", "auth": "auth"}}
+        db.update_web_subscription("user1", "web-dev1", subscription)
+        self.assertEqual(db.get_web_subscriptions_with_device_id("user1"), {"web-dev1": subscription})
+
+    def test_remove_device(self):
+        subscription = {"endpoint": "https://push.example.com/1", "keys": {"p256dh": "p256", "auth": "auth"}}
+        db.update_web_subscription("user1", "web-dev1", subscription)
+        resp = db.remove_device("user1", "web-dev1")
+        self.assertEqual(resp, "Device 'web-dev1' removed for user 'user1'.")
+        self.assertEqual(db.get_web_subscriptions("user1"), [])
+
+    def test_remove_device_not_found(self):
+        resp = db.remove_device("user1", "unknown-dev")
+        self.assertEqual(resp, "No device 'unknown-dev' found for user 'user1'.")
+
+    def test_get_vapid_keys_generates_and_persists(self):
+        keys = db.get_vapid_keys()
+        self.assertIn("private_key", keys)
+        self.assertIn("public_key", keys)
+        self.assertEqual(keys["subject"], "mailto:admin@example.com")
+        self.assertEqual(db._DB_FULL['app-config']['vapid_private_key'], keys["private_key"])
+
+    def test_get_vapid_keys_cached(self):
+        first = db.get_vapid_keys()
+        second = db.get_vapid_keys()
+        self.assertEqual(first, second)
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -40,13 +40,58 @@ class TestMain(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual({"fcm_token": "mock_token"}, response.json())
 
+    @patch("app.main.db")
+    def test_get_vapid_public_key(self, mock_db):
+        mock_db.get_vapid_keys.return_value = {"public_key": "mock_public_key", "private_key": "x", "subject": "y"}
+        response = client.get("/api/vapid-public-key")
+
+        mock_db.get_vapid_keys.assert_called_once()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual({"public_key": "mock_public_key"}, response.json())
+
+    @patch("app.main.db")
+    def test_register_web_push(self, mock_db):
+        mock_db.user_exits.return_value = True
+        mock_db.update_web_subscription.return_value = "mocked fun called"
+        payload = {
+            "device_id": "web-dev1",
+            "username": "sip_user",
+            "subscription": {
+                "endpoint": "https://push.example.com/1",
+                "keys": {"p256dh": "p256", "auth": "auth"}
+            }
+        }
+        response = client.post("/sip/client/register/web-push", json=payload)
+
+        mock_db.update_web_subscription.assert_called_once_with("sip_user", "web-dev1", payload["subscription"])
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual({"message": "mocked fun called"}, response.json())
+
+    @patch("app.main.db")
+    def test_register_web_push_user_not_found(self, mock_db):
+        mock_db.user_exits.return_value = False
+        payload = {
+            "device_id": "web-dev1",
+            "username": "sip_user",
+            "subscription": {
+                "endpoint": "https://push.example.com/1",
+                "keys": {"p256dh": "p256", "auth": "auth"}
+            }
+        }
+        response = client.post("/sip/client/register/web-push", json=payload)
+
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.json(), {"detail": "User name not present."})
+
     @patch("app.main.sql_db")
     @patch("app.main.db")
+    @patch("app.main.push_web_call_alert", new_callable=AsyncMock)
     @patch("app.main.push_call_alert", new_callable=AsyncMock)
-    def test_alert_client_on_call_success(self, mock_push_call_alert, mock_db, mock_sql_db):
+    def test_alert_client_on_call_success(self, mock_push_call_alert, mock_push_web_call_alert, mock_db, mock_sql_db):
         mock_db.user_exits.return_value = True
         mock_sql_db.insert_call_log.return_value = None
         mock_push_call_alert.return_value = [{"status": 200, "data": {"name": "projects/test/messages/123"}}]
+        mock_push_web_call_alert.return_value = [{"status": 201, "data": {"message": "Push sent"}}]
         payload = {
             "username": "sip_user",
             "phone_number": "+1234567890",
@@ -58,8 +103,12 @@ class TestMain(unittest.IsolatedAsyncioTestCase):
                                                             json.dumps(payload, indent=None, separators=(',', ':')))
         mock_db.user_exits.assert_called_once_with("sip_user")
         mock_push_call_alert.assert_awaited_once_with("sip_user", "+1234567890", payload)
+        mock_push_web_call_alert.assert_awaited_once_with("sip_user", "+1234567890", payload)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), [{"status": 200, "data": {"name": "projects/test/messages/123"}}])
+        self.assertEqual(response.json(), [
+            {"status": 200, "data": {"name": "projects/test/messages/123"}},
+            {"status": 201, "data": {"message": "Push sent"}}
+        ])
 
     @patch("app.main.db")
     def test_alert_client_on_call_user_not_found(self, mock_db):
@@ -77,11 +126,13 @@ class TestMain(unittest.IsolatedAsyncioTestCase):
 
     @patch("app.main.sql_db")
     @patch("app.main.db")
+    @patch("app.main.push_web_sms_alert", new_callable=AsyncMock)
     @patch("app.main.push_sms_alert", new_callable=AsyncMock)
-    def test_alert_client_on_sms_success(self, mock_push_sms_alert, mock_db, mock_sql_db):
+    def test_alert_client_on_sms_success(self, mock_push_sms_alert, mock_push_web_sms_alert, mock_db, mock_sql_db):
         mock_db.user_exits.return_value = True
         mock_sql_db.insert_sms_log.return_value = None
         mock_push_sms_alert.return_value = [{"status": 200, "data": {"name": "projects/test/messages/456"}}]
+        mock_push_web_sms_alert.return_value = [{"status": 201, "data": {"message": "Push sent"}}]
         payload = {
             "username": "sip_user",
             "phone_number": "+1234567890",
@@ -95,8 +146,12 @@ class TestMain(unittest.IsolatedAsyncioTestCase):
                                                            json.dumps(payload, indent=None, separators=(',', ':')))
         mock_db.user_exits.assert_called_once_with("sip_user")
         mock_push_sms_alert.assert_awaited_once_with("sip_user", "+1234567890", "Hello!", None)
+        mock_push_web_sms_alert.assert_awaited_once_with("sip_user", "+1234567890", "Hello!", None)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), [{"status": 200, "data": {"name": "projects/test/messages/456"}}])
+        self.assertEqual(response.json(), [
+            {"status": 200, "data": {"name": "projects/test/messages/456"}},
+            {"status": 201, "data": {"message": "Push sent"}}
+        ])
 
     @patch("app.main.db")
     def test_alert_client_on_sms_user_not_found(self, mock_db):


### PR DESCRIPTION
Adds a VAPID-based web push delivery channel alongside the existing FCM path, so browser clients can subscribe and receive call/SMS alerts as desktop notifications, with the same targeting/exclusion behavior as Android devices.