### PR TITLE
Add endpoint to unregister a device (FCM or web-push)

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -114,6 +114,13 @@ async def register_web_push(payload: WebPushTokenPayload):
     message = db.update_web_subscription(payload.username, payload.device_id, payload.subscription.model_dump())
     return MessageResponse(message=message)
 
+@app.delete("/sip/client/{username}/{device_id}", response_model=MessageResponse)
+async def unregister_device(username: str, device_id: str):
+    if not db.user_exits(username):
+        raise HTTPException(status_code=404, detail="User name not present.")
+    message = db.remove_device(username, device_id)
+    return MessageResponse(message=message)
+
 @app.post("/sip/alert/call", response_model=List[FirebaseResponse])
 async def alert_client_on_call(payload: CallPayload):
     if not db.user_exits(payload.username):

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -83,6 +83,25 @@ class TestMain(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(response.status_code, 404)
         self.assertEqual(response.json(), {"detail": "User name not present."})
 
+    @patch("app.main.db")
+    def test_unregister_device(self, mock_db):
+        mock_db.user_exits.return_value = True
+        mock_db.remove_device.return_value = "Device 'abc123' removed for user 'sip_user'."
+        response = client.delete("/sip/client/sip_user/abc123")
+
+        mock_db.remove_device.assert_called_once_with("sip_user", "abc123")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual({"message": "Device 'abc123' removed for user 'sip_user'."}, response.json())
+
+    @patch("app.main.db")
+    def test_unregister_device_user_not_found(self, mock_db):
+        mock_db.user_exits.return_value = False
+        response = client.delete("/sip/client/sip_user/abc123")
+
+        mock_db.remove_device.assert_not_called()
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.json(), {"detail": "User name not present."})
+
     @patch("app.main.sql_db")
     @patch("app.main.db")
     @patch("app.main.push_web_call_alert", new_callable=AsyncMock)


### PR DESCRIPTION
Allows removing a device's registration regardless of whether it was registered via FCM token or web-push subscription, reusing db.remove_device.