### PR TITLE
Add device management UI

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -13,7 +13,8 @@ import app.database_sqlite as sql_db
 from app.models import (User, TokenPayload, CallPayload, SmsPayload, RestartPayload,
                         MessageResponse, DeviceResponse, FirebaseResponse,
                         SmsLogEntry, CallLogEntry, SmsLogsResponse, CallLogsResponse,
-                        UserResponse, ConfigResponse, WebPushTokenPayload, VapidKeyResponse)
+                        UserResponse, ConfigResponse, WebPushTokenPayload, VapidKeyResponse,
+                        DeviceInfo)
 from app.services.asterisk import restart_asterisk, configure_asterisk
 from app.services.firebase import push_call_alert, push_sms_alert
 from app.services.webpush import push_web_call_alert, push_web_sms_alert
@@ -120,6 +121,21 @@ async def unregister_device(username: str, device_id: str):
         raise HTTPException(status_code=404, detail="User name not present.")
     message = db.remove_device(username, device_id)
     return MessageResponse(message=message)
+
+@app.get("/sip/users/{username}/devices", response_model=List[DeviceInfo])
+async def get_user_devices(username: str):
+    user = db.get_user_data(username)
+    if not user:
+        raise HTTPException(status_code=404, detail="User name not present.")
+    devices = user.get('devices') or {}
+    return [
+        DeviceInfo(
+            device_id=device_id,
+            fcm_registered=bool(device.get('fcm_token')),
+            web_push_registered=bool(device.get('web_subscription'))
+        )
+        for device_id, device in devices.items()
+    ]
 
 @app.post("/sip/alert/call", response_model=List[FirebaseResponse])
 async def alert_client_on_call(payload: CallPayload):

--- a/app/models.py
+++ b/app/models.py
@@ -110,3 +110,8 @@ class UserResponse(BaseModel):
 class ConfigResponse(BaseModel):
     sa_configured: bool
     project_id: str
+
+class DeviceInfo(BaseModel):
+    device_id: str
+    fcm_registered: bool
+    web_push_registered: bool

--- a/frontend/src/api/index.js
+++ b/frontend/src/api/index.js
@@ -26,6 +26,10 @@ export const api = {
   updateUser:   (username, data) => request('PUT',    `/sip/users/${username}`, data),
   deleteUser:   (username)       => request('DELETE', `/sip/users/${username}`),
 
+  // Devices
+  getUserDevices: (username)             => request('GET',    `/sip/users/${username}/devices`),
+  removeDevice:   (username, deviceId)   => request('DELETE', `/sip/client/${username}/${deviceId}`),
+
   // Config
   getConfig:    ()       => request('GET', '/api/config'),
   getTtyDevices: ()      => request('GET', '/api/tty-devices'),

--- a/frontend/src/components/DeviceListDialog.vue
+++ b/frontend/src/components/DeviceListDialog.vue
@@ -1,0 +1,85 @@
+<script setup>
+import { ref, watch } from 'vue'
+import { api } from '../api'
+
+const props = defineProps({
+  modelValue: Boolean,
+  username: { type: String, default: '' },
+})
+const emit = defineEmits(['update:modelValue', 'error'])
+
+const devices    = ref([])
+const loading    = ref(false)
+const removingId = ref('')
+
+async function loadDevices() {
+  if (!props.username) return
+  loading.value = true
+  try {
+    devices.value = await api.getUserDevices(props.username)
+  } catch (e) {
+    emit('error', e.message)
+  } finally {
+    loading.value = false
+  }
+}
+
+watch(() => props.modelValue, (open) => {
+  if (open) loadDevices()
+})
+
+async function removeDevice(device) {
+  if (!confirm(`Remove device "${device.device_id}" for user ${props.username}?`)) return
+  removingId.value = device.device_id
+  try {
+    await api.removeDevice(props.username, device.device_id)
+    devices.value = devices.value.filter(d => d.device_id !== device.device_id)
+  } catch (e) {
+    emit('error', e.message)
+  } finally {
+    removingId.value = ''
+  }
+}
+</script>
+
+<template>
+  <v-dialog
+    :model-value="modelValue"
+    max-width="500"
+    @update:model-value="emit('update:modelValue', $event)"
+  >
+    <v-card>
+      <v-card-title class="d-flex align-center">
+        <v-icon start>mdi-cellphone-link</v-icon>
+        Devices for {{ username }}
+      </v-card-title>
+      <v-card-text>
+        <div v-if="loading" class="d-flex justify-center pa-4">
+          <v-progress-circular indeterminate color="primary" />
+        </div>
+        <v-list v-else-if="devices.length">
+          <v-list-item v-for="device in devices" :key="device.device_id">
+            <v-list-item-title>{{ device.device_id }}</v-list-item-title>
+            <template #append>
+              <v-chip v-if="device.fcm_registered" size="small" color="primary" class="me-1">FCM</v-chip>
+              <v-chip v-if="device.web_push_registered" size="small" color="info" class="me-2">Web Push</v-chip>
+              <v-btn
+                icon="mdi-delete"
+                variant="text"
+                size="small"
+                color="error"
+                :loading="removingId === device.device_id"
+                @click="removeDevice(device)"
+              />
+            </template>
+          </v-list-item>
+        </v-list>
+        <p v-else class="text-medium-emphasis pa-2">No devices registered.</p>
+      </v-card-text>
+      <v-card-actions>
+        <v-spacer />
+        <v-btn variant="text" @click="emit('update:modelValue', false)">Close</v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+</template>

--- a/frontend/src/components/UserTable.vue
+++ b/frontend/src/components/UserTable.vue
@@ -2,13 +2,16 @@
 import { ref, onMounted } from 'vue'
 import { api } from '../api'
 import UserFormDialog from './UserFormDialog.vue'
+import DeviceListDialog from './DeviceListDialog.vue'
 
 const users          = ref([])
 const loading        = ref(true)
 const formDialog     = ref(false)
 const deleteDialog   = ref(false)
+const devicesDialog  = ref(false)
 const editingUser    = ref(null)
 const deletingUser   = ref('')
+const devicesUser    = ref('')
 const snackbar       = ref({ show: false, message: '', color: 'success' })
 
 const headers = [
@@ -43,6 +46,11 @@ function openEdit(user) {
 function confirmDelete(username) {
   deletingUser.value = username
   deleteDialog.value = true
+}
+
+function openDevices(username) {
+  devicesUser.value = username
+  devicesDialog.value = true
 }
 
 async function deleteUser() {
@@ -87,6 +95,7 @@ onMounted(loadUsers)
       :mobile-breakpoint="600"
     >
       <template #item.actions="{ item }">
+        <v-btn icon="mdi-cellphone-link" variant="text" size="small" @click="openDevices(item.username)" />
         <v-btn icon="mdi-pencil" variant="text" size="small" @click="openEdit(item)" />
         <v-btn icon="mdi-delete" variant="text" size="small" color="error" @click="confirmDelete(item.username)" />
       </template>
@@ -97,6 +106,12 @@ onMounted(loadUsers)
     v-model="formDialog"
     :user="editingUser"
     @saved="onSaved"
+    @error="showSnackbar($event, 'error')"
+  />
+
+  <DeviceListDialog
+    v-model="devicesDialog"
+    :username="devicesUser"
     @error="showSnackbar($event, 'error')"
   />
 

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -257,6 +257,40 @@ class TestMain(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(response.json(), {"detail": "User name not present."})
 
     # ------------------------------------------------------------------
+    # GET /sip/users/{username}/devices
+    # ------------------------------------------------------------------
+
+    @patch("app.main.db")
+    def test_get_user_devices_success(self, mock_db):
+        mock_db.get_user_data.return_value = {
+            'username': 'alice',
+            'devices': {
+                'dev1': {'device_id': 'dev1', 'fcm_token': 'token_xyz'},
+                'dev2': {'device_id': 'dev2', 'web_subscription': {'endpoint': 'https://push.example.com/1'}}
+            }
+        }
+        response = client.get("/sip/users/alice/devices")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), [
+            {'device_id': 'dev1', 'fcm_registered': True, 'web_push_registered': False},
+            {'device_id': 'dev2', 'fcm_registered': False, 'web_push_registered': True}
+        ])
+
+    @patch("app.main.db")
+    def test_get_user_devices_empty(self, mock_db):
+        mock_db.get_user_data.return_value = {'username': 'alice'}
+        response = client.get("/sip/users/alice/devices")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), [])
+
+    @patch("app.main.db")
+    def test_get_user_devices_user_not_found(self, mock_db):
+        mock_db.get_user_data.return_value = None
+        response = client.get("/sip/users/nonexistent/devices")
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.json(), {"detail": "User name not present."})
+
+    # ------------------------------------------------------------------
     # GET /api/tty-devices
     # ------------------------------------------------------------------
 


### PR DESCRIPTION
Expose registered devices per user via a new /sip/users/{username}/devices endpoint, and add a Vuetify dialog to view and remove FCM/web-push devices directly from the dashboard user table.