### PR TITLE
Split combined logs page into separate Call Logs and SMS Logs pages

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -11,7 +11,8 @@ const route = useRoute()
         SIPConnect
       </v-app-bar-title>
       <v-btn variant="text" to="/" :active="route.path === '/'">Dashboard</v-btn>
-      <v-btn variant="text" to="/logs" :active="route.path === '/logs'">Logs</v-btn>
+      <v-btn variant="text" to="/logs/calls" :active="route.path === '/logs/calls'">Call Logs</v-btn>
+      <v-btn variant="text" to="/logs/sms" :active="route.path === '/logs/sms'">SMS Logs</v-btn>
       <v-btn variant="text" to="/notifications" :active="route.path === '/notifications'">Notifications</v-btn>
     </v-app-bar>
 

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -1,11 +1,13 @@
 import { createRouter, createWebHistory } from 'vue-router'
 import Dashboard from '../views/Dashboard.vue'
-import Logs from '../views/Logs.vue'
+import CallLogs from '../views/CallLogs.vue'
+import SmsLogs from '../views/SmsLogs.vue'
 import Notifications from '../views/Notifications.vue'
 
 const routes = [
   { path: '/', component: Dashboard },
-  { path: '/logs', component: Logs },
+  { path: '/logs/calls', component: CallLogs },
+  { path: '/logs/sms', component: SmsLogs },
   { path: '/notifications', component: Notifications },
 ]
 

--- a/frontend/src/views/CallLogs.vue
+++ b/frontend/src/views/CallLogs.vue
@@ -3,7 +3,6 @@ import { ref, onMounted } from 'vue'
 import { api } from '../api'
 
 const callLogs = ref([])
-const smsLogs  = ref([])
 const loading  = ref(true)
 const error    = ref('')
 
@@ -14,20 +13,9 @@ const callHeaders = [
   { title: 'Timestamp', key: 'timestamp' },
 ]
 
-const smsHeaders = [
-  { title: 'ID',        key: 'id',        width: '80px' },
-  { title: 'User',      key: 'user' },
-  { title: 'Number',    key: 'number' },
-  { title: 'Message',   key: 'message' },
-  { title: 'Type',      key: 'sms_type' },
-  { title: 'Timestamp', key: 'timestamp' },
-]
-
 onMounted(async () => {
   try {
-    const [callData, smsData] = await Promise.all([api.getCallLogs(), api.getSmsLogs()])
-    callLogs.value = callData.data
-    smsLogs.value  = smsData.data
+    callLogs.value = (await api.getCallLogs()).data
   } catch (e) {
     error.value = e.message
   } finally {
@@ -40,7 +28,7 @@ onMounted(async () => {
   <v-container fluid class="pa-2 pa-sm-6">
     <v-alert v-if="error" type="error" class="mb-4">{{ error }}</v-alert>
 
-    <v-card class="mb-6">
+    <v-card>
       <v-card-title>
         <v-icon start>mdi-phone</v-icon>
         Call Logs
@@ -48,21 +36,6 @@ onMounted(async () => {
       <v-data-table
         :headers="callHeaders"
         :items="callLogs"
-        :loading="loading"
-        :items-per-page="20"
-        :sort-by="[{ key: 'timestamp', order: 'desc' }]"
-        :mobile-breakpoint="600"
-      />
-    </v-card>
-
-    <v-card>
-      <v-card-title>
-        <v-icon start>mdi-message-text</v-icon>
-        SMS Logs
-      </v-card-title>
-      <v-data-table
-        :headers="smsHeaders"
-        :items="smsLogs"
         :loading="loading"
         :items-per-page="20"
         :sort-by="[{ key: 'timestamp', order: 'desc' }]"

--- a/frontend/src/views/SmsLogs.vue
+++ b/frontend/src/views/SmsLogs.vue
@@ -1,0 +1,48 @@
+<script setup>
+import { ref, onMounted } from 'vue'
+import { api } from '../api'
+
+const smsLogs = ref([])
+const loading = ref(true)
+const error   = ref('')
+
+const smsHeaders = [
+  { title: 'ID',        key: 'id',        width: '80px' },
+  { title: 'User',      key: 'user' },
+  { title: 'Number',    key: 'number' },
+  { title: 'Message',   key: 'message' },
+  { title: 'Type',      key: 'sms_type' },
+  { title: 'Timestamp', key: 'timestamp' },
+]
+
+onMounted(async () => {
+  try {
+    smsLogs.value = (await api.getSmsLogs()).data
+  } catch (e) {
+    error.value = e.message
+  } finally {
+    loading.value = false
+  }
+})
+</script>
+
+<template>
+  <v-container fluid class="pa-2 pa-sm-6">
+    <v-alert v-if="error" type="error" class="mb-4">{{ error }}</v-alert>
+
+    <v-card>
+      <v-card-title>
+        <v-icon start>mdi-message-text</v-icon>
+        SMS Logs
+      </v-card-title>
+      <v-data-table
+        :headers="smsHeaders"
+        :items="smsLogs"
+        :loading="loading"
+        :items-per-page="20"
+        :sort-by="[{ key: 'timestamp', order: 'desc' }]"
+        :mobile-breakpoint="600"
+      />
+    </v-card>
+  </v-container>
+</template>


### PR DESCRIPTION
Replaces the single /logs page with /logs/calls and /logs/sms, each linked from the nav bar, so call and SMS history can be viewed independently.