### PR TITLE
Add start.sh setup script and move data dir to a fixed path

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,8 +8,9 @@ services:
     privileged: true
     network_mode: host  # Required for SIP/RTP ports and USB dongle access
     volumes:
-      - ~/data.json:/app/app/data.json
-      - ~/master.db:/var/log/asterisk/master.db
+      - /var/lib/sipconnect/data.json:/app/app/data.json
+      - /var/lib/sipconnect/service-account.json:/app/uploads/service-account.json
+      - /var/lib/sipconnect/master.db:/var/log/asterisk/master.db
     restart: unless-stopped
 
   nginx:
@@ -25,17 +26,17 @@ services:
     restart: unless-stopped
 
 # -----------------------------------------------------------------------
-# Before first run:
+# First run and upgrades:
 #
-# 1. Build the Vue frontend:
-#      cd frontend && npm install && npm run build
+#   ./start.sh
 #
-# 2. Generate a self-signed certificate (or use mkcert for no warnings):
-#      mkdir -p certs
-#      openssl req -x509 -newkey rsa:4096 -nodes -keyout certs/key.pem -out certs/cert.pem -days 365 -subj "/CN=sipconnect"
+# This builds the Vue frontend, generates a self-signed cert if missing,
+# seeds /var/lib/sipconnect/{data.json,master.db,service-account.json}
+# if missing (Docker bind-mounts a missing file source as a directory,
+# which breaks the app), then runs `docker-compose up -d --build`.
 #
-# 3. Start everything:
-#      docker-compose up -d --build
+# The data dir is a fixed absolute path (not ~) so it resolves the same
+# regardless of which user or sudo invokes docker-compose/start.sh.
 #
 # Development (without Docker):
 #   Terminal 1: uvicorn app.main:app --reload

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,70 @@
+#!/bin/sh
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$SCRIPT_DIR"
+
+# Fixed absolute path (not ~) so it resolves the same regardless of which
+# user or sudo runs this script or docker-compose directly.
+DATA_DIR="${SIPCONNECT_DATA_DIR:-/var/lib/sipconnect}"
+
+echo "==> Building frontend"
+(cd frontend && npm install && npm run build)
+
+echo "==> Checking TLS certificate"
+if [ ! -f certs/cert.pem ] || [ ! -f certs/key.pem ]; then
+  echo "    No certs found in certs/, generating a self-signed one"
+  mkdir -p certs
+  openssl req -x509 -newkey rsa:4096 -nodes \
+    -keyout certs/key.pem -out certs/cert.pem -days 365 -subj "/CN=sipconnect"
+else
+  echo "    Existing certs found, skipping"
+fi
+
+OLD_DATA_DIR="$HOME/SIPConnectServerData"
+if [ -f "$OLD_DATA_DIR/data.json" ] && [ ! -f "$DATA_DIR/data.json" ]; then
+  echo "==> Found existing data at $OLD_DATA_DIR (old default location)"
+  echo "    Move it to $DATA_DIR before continuing, e.g.:"
+  echo "      sudo mkdir -p $DATA_DIR && sudo mv $OLD_DATA_DIR/* $DATA_DIR/"
+  exit 1
+fi
+
+echo "==> Checking data directory ($DATA_DIR)"
+if ! mkdir -p "$DATA_DIR" 2>/dev/null; then
+  echo "    $DATA_DIR needs elevated privileges to create, retrying with sudo"
+  sudo mkdir -p "$DATA_DIR"
+  sudo chown "$(id -u):$(id -g)" "$DATA_DIR"
+fi
+
+if [ ! -f "$DATA_DIR/data.json" ]; then
+  echo "    Seeding data.json"
+  cat > "$DATA_DIR/data.json" <<'EOF'
+{
+  "db_version": "0.01",
+  "app-config": {
+    "service_account_file": "uploads/dummy-service-account.json",
+    "firebase_project_id": "dummy-project-id"
+  },
+  "users": []
+}
+EOF
+else
+  echo "    Existing data.json found, skipping"
+fi
+
+if [ ! -f "$DATA_DIR/master.db" ]; then
+  echo "    Creating empty master.db"
+  touch "$DATA_DIR/master.db"
+else
+  echo "    Existing master.db found, skipping"
+fi
+
+if [ ! -f "$DATA_DIR/service-account.json" ]; then
+  echo "    Creating placeholder service-account.json"
+  touch "$DATA_DIR/service-account.json"
+else
+  echo "    Existing service-account.json found, skipping"
+fi
+
+echo "==> Starting Docker Compose"
+docker-compose up -d --build


### PR DESCRIPTION
Adds start.sh to build the frontend, generate a self-signed cert, seed the data files, and run docker-compose in one step, replacing manual first-run instructions. Also moves the bind-mounted data directory from ~/SIPConnectServerData to /var/lib/sipconnect so it resolves consistently regardless of which user or sudo context runs docker-compose, which matters now that the project is being shared with other operators.