### PR TITLE
Rename SIPConnectServer to SimLinkServer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@ CI runs on push to `dev` and all pull requests via `.github/workflows/python-app
 
 ## Architecture
 
-**SIPConnectServer** is a FastAPI server that acts as the management and notification layer on top of Asterisk PBX. It enables SIP-based voice communication via USB GSM dongles and pushes call/SMS alerts to Android clients via Firebase.
+**SimLinkServer** is a FastAPI server that acts as the management and notification layer on top of Asterisk PBX. It enables SIP-based voice communication via USB GSM dongles and pushes call/SMS alerts to Android clients via Firebase.
 
 ### Core Data Flow
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ RUN apt-get install -y \
     curl
 #     && rm -rf /var/lib/apt/lists/*
 
-# SIPConnect server
+# SimLinkServer
 WORKDIR /app
 COPY requirements.txt /app
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -38,7 +38,7 @@ RUN apt-get install -y \
     supervisor
 #     && rm -rf /var/lib/apt/lists/*
 
-# SIPConnect server
+# SimLinkServer
 WORKDIR /app
 COPY requirements.txt /app
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-[![Build Status](https://github.com/shaeed/SIPConnectServer/actions/workflows/python-app.yml/badge.svg)](https://github.com/shaeed/SIPConnectServer/actions/workflows/python-app.yml) [![CodeQL](https://github.com/shaeed/SIPConnectServer/actions/workflows/github-code-scanning/codeql/badge.svg)](https://github.com/shaeed/SIPConnectServer/actions/workflows/github-code-scanning/codeql)
+[![Build Status](https://github.com/shaeed/SimLinkServer/actions/workflows/python-app.yml/badge.svg)](https://github.com/shaeed/SimLinkServer/actions/workflows/python-app.yml) [![CodeQL](https://github.com/shaeed/SimLinkServer/actions/workflows/github-code-scanning/codeql/badge.svg)](https://github.com/shaeed/SimLinkServer/actions/workflows/github-code-scanning/codeql)
 
-# SIPConnectServer
+# SimLinkServer
 
-**SIPConnectServer** is a management and notification layer on top of Asterisk PBX. It lets you run SIP-based voice/SMS communication through USB GSM dongles, and pushes call/SMS alerts to Android and browser clients in real time.
+**SimLinkServer** is a management and notification layer on top of Asterisk PBX. It lets you run SIP-based voice/SMS communication through USB GSM dongles, and pushes call/SMS alerts to Android and browser clients in real time.
 This project aims to provide a simple, self-hosted solution for SIP-based voice communication in a local environment (to be used with VPN).
 
 ---
@@ -37,10 +37,10 @@ This project aims to provide a simple, self-hosted solution for SIP-based voice 
 
 The stack runs as two containers behind `docker-compose`:
 
-- **`sipconnect`** — Asterisk + FastAPI (`app/`), managed by `supervisord`. Generates Asterisk config from a JSON user database, handles SIP/SMS alerts, and serves the REST API.
+- **`simlink`** — Asterisk + FastAPI (`app/`), managed by `supervisord`. Generates Asterisk config from a JSON user database, handles SIP/SMS alerts, and serves the REST API.
 - **`nginx`** — terminates TLS, serves the built Vue frontend (`frontend/dist`), and proxies `/sip`, `/api`, `/gsm`, `/upload_sa` to the FastAPI service.
 
-Persistent state (`data.json`, `master.db`, `service-account.json`) is bind-mounted from a fixed host path (`/var/lib/sipconnect` by default) so it survives container rebuilds.
+Persistent state (`data.json`, `master.db`, `service-account.json`) is bind-mounted from a fixed host path (`/var/lib/simlink` by default) so it survives container rebuilds.
 
 ---
 
@@ -49,15 +49,15 @@ Persistent state (`data.json`, `master.db`, `service-account.json`) is bind-moun
 - **Docker** and **Docker Compose**
 - **Node.js/npm** (only needed to build the frontend — `start.sh` runs this for you)
 - A USB GSM dongle with a SIM card
-- `sudo` access (the SIP container needs `privileged: true` for dongle access, and `/var/lib/sipconnect` is root-owned by default)
+- `sudo` access (the SIP container needs `privileged: true` for dongle access, and `/var/lib/simlink` is root-owned by default)
 
 ---
 
 ## Quick Start (Docker)
 
 ```bash
-git clone https://github.com/shaeed/SIPConnectServer.git
-cd SIPConnectServer
+git clone https://github.com/shaeed/SimLinkServer.git
+cd SimLinkServer
 ./start.sh
 ```
 
@@ -65,7 +65,7 @@ cd SIPConnectServer
 
 1. Builds the Vue frontend (`cd frontend && npm install && npm run build`)
 2. Generates a self-signed TLS certificate under `certs/` if one doesn't already exist
-3. Seeds `data.json`, `master.db`, and `service-account.json` under the data directory (default `/var/lib/sipconnect`, override with `SIPCONNECT_DATA_DIR`) if they don't already exist — this avoids a Docker bind-mount pitfall where a missing source file gets silently created as a directory instead
+3. Seeds `data.json`, `master.db`, and `service-account.json` under the data directory (default `/var/lib/simlink`, override with `SIMLINK_DATA_DIR`) if they don't already exist — this avoids a Docker bind-mount pitfall where a missing source file gets silently created as a directory instead
 4. Runs `docker-compose up -d --build`
 
 Once it's up, open `https://<server-ip>/` (you'll need to accept the self-signed cert warning unless you swap in your own certificate) to reach the admin dashboard. From there:
@@ -136,7 +136,7 @@ CI runs these on every push to `dev` and on all pull requests.
 
 | Setting | Where | Notes |
 |---|---|---|
-| Data directory | `SIPCONNECT_DATA_DIR` env var (used by `start.sh`) | Defaults to `/var/lib/sipconnect`; must be an absolute path so it resolves the same under `sudo` or any user |
+| Data directory | `SIMLINK_DATA_DIR` env var (used by `start.sh`) | Defaults to `/var/lib/simlink`; must be an absolute path so it resolves the same under `sudo` or any user |
 | Firebase service account | Dashboard → Config card (`/upload_sa`) | Required for FCM/Web Push alerts to be sent |
 | SIP port | `docker-compose.yml` (`network_mode: host`) | UDP 5060, standard SIP |
 | Dashboard/API | `nginx` | HTTPS on 443 (redirects from 80), proxies to FastAPI on `127.0.0.1:8000` |

--- a/app/templates/home.html
+++ b/app/templates/home.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>SipConnectServer Configure</title>
+    <title>SimLinkServer Configure</title>
 </head>
 <body>
     <h1>Submit your info</h1>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,28 +1,28 @@
 
 services:
-  sipconnect:
+  simlink:
     build:
       context: .
       dockerfile: Dockerfile
-    container_name: sipconnect
+    container_name: simlink
     privileged: true
     network_mode: host  # Required for SIP/RTP ports and USB dongle access
     volumes:
-      - /var/lib/sipconnect/data.json:/app/app/data.json
-      - /var/lib/sipconnect/service-account.json:/app/uploads/service-account.json
-      - /var/lib/sipconnect/master.db:/var/log/asterisk/master.db
+      - /var/lib/simlink/data.json:/app/app/data.json
+      - /var/lib/simlink/service-account.json:/app/uploads/service-account.json
+      - /var/lib/simlink/master.db:/var/log/asterisk/master.db
     restart: unless-stopped
 
   nginx:
     image: nginx:alpine
-    container_name: sipconnect-nginx
+    container_name: simlink-nginx
     network_mode: host  # Same host network so it can proxy to localhost:8000
     volumes:
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
       - ./frontend/dist:/usr/share/nginx/html:ro
       - ./certs:/etc/nginx/certs:ro
     depends_on:
-      - sipconnect
+      - simlink
     restart: unless-stopped
 
 # -----------------------------------------------------------------------
@@ -31,7 +31,7 @@ services:
 #   ./start.sh
 #
 # This builds the Vue frontend, generates a self-signed cert if missing,
-# seeds /var/lib/sipconnect/{data.json,master.db,service-account.json}
+# seeds /var/lib/simlink/{data.json,master.db,service-account.json}
 # if missing (Docker bind-mounts a missing file source as a directory,
 # which breaks the app), then runs `docker-compose up -d --build`.
 #

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>SIPConnect</title>
+    <title>SimLink</title>
     <link
       href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap"
       rel="stylesheet"

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "sipconnect-frontend",
+  "name": "simlink-frontend",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "sipconnect-frontend",
+      "name": "simlink-frontend",
       "version": "0.1.0",
       "dependencies": {
         "@mdi/font": "^7.4.47",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "sipconnect-frontend",
+  "name": "simlink-frontend",
   "version": "0.1.0",
   "scripts": {
     "dev": "vite",

--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -1,6 +1,6 @@
 self.addEventListener('push', (event) => {
   const payload = event.data ? event.data.json() : {}
-  const title = payload.title || 'SIPConnect'
+  const title = payload.title || 'SimLink'
   const options = {
     body: payload.body || '',
     icon: '/favicon.ico',

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -8,7 +8,7 @@ const route = useRoute()
     <v-app-bar color="primary" elevation="2">
       <v-app-bar-title>
         <v-icon start>mdi-phone-voip</v-icon>
-        SIPConnect
+        SimLink
       </v-app-bar-title>
       <v-btn variant="text" to="/" :active="route.path === '/'">Dashboard</v-btn>
       <v-btn variant="text" to="/logs/calls" :active="route.path === '/logs/calls'">Call Logs</v-btn>

--- a/start.sh
+++ b/start.sh
@@ -6,7 +6,7 @@ cd "$SCRIPT_DIR"
 
 # Fixed absolute path (not ~) so it resolves the same regardless of which
 # user or sudo runs this script or docker-compose directly.
-DATA_DIR="${SIPCONNECT_DATA_DIR:-/var/lib/sipconnect}"
+DATA_DIR="${SIMLINK_DATA_DIR:-/var/lib/simlink}"
 
 echo "==> Building frontend"
 (cd frontend && npm install && npm run build)
@@ -16,7 +16,7 @@ if [ ! -f certs/cert.pem ] || [ ! -f certs/key.pem ]; then
   echo "    No certs found in certs/, generating a self-signed one"
   mkdir -p certs
   openssl req -x509 -newkey rsa:4096 -nodes \
-    -keyout certs/key.pem -out certs/cert.pem -days 365 -subj "/CN=sipconnect"
+    -keyout certs/key.pem -out certs/cert.pem -days 365 -subj "/CN=simlink"
 else
   echo "    Existing certs found, skipping"
 fi


### PR DESCRIPTION
Rebrands the server to pair with the SimLink mobile app: updates docs, env vars, data dir path, container/service names, and frontend branding. GitHub repo rename and local folder rename are still pending manually.